### PR TITLE
Minor ox-confluence additions

### DIFF
--- a/contrib/lisp/ox-confluence.el
+++ b/contrib/lisp/ox-confluence.el
@@ -55,7 +55,8 @@
 		     (table-cell . org-confluence-table-cell)
 		     (table-row . org-confluence-table-row)
 		     (template . org-confluence-template)
-		     (underline . org-confluence-underline)))
+		     (underline . org-confluence-underline)
+		     (verbatim . org-confluence-verbatim)))
 
 ;; All the functions we use
 (defun org-confluence-bold (bold contents info)
@@ -142,6 +143,10 @@
 
 (defun org-confluence-underline (underline contents info)
   (format "+%s+" contents))
+
+(defun org-confluence-verbatim (verbatim contents info)
+  (format "\{\{%s\}\}"
+	  (org-element-property :value verbatim)))
 
 (defun org-confluence--block (language theme contents)
   (concat "\{code:theme=" theme

--- a/contrib/lisp/ox-confluence.el
+++ b/contrib/lisp/ox-confluence.el
@@ -74,9 +74,23 @@
   (format "_%s_" contents))
 
 (defun org-confluence-item (item contents info)
-  (concat (make-string (1+ (org-confluence--li-depth item)) ?\-)
+  (let* ((plain-list (org-export-get-parent item))
+	 (type (org-element-property :type plain-list))
+	 (term (let ((tag (org-element-property :tag item)))
+		 (and tag (org-export-data tag info)))))
+    (case type
+      (ordered
+       (concat (make-string (1+ (org-confluence--li-depth item)) ?\#)
           " "
           (org-trim contents)))
+      (unordered
+       (concat (make-string (1+ (org-confluence--li-depth item)) ?\*)
+          " "
+          (org-trim contents)))
+      (descriptive
+	 (concat (make-string (1+ (org-confluence--li-depth item)) ?\*)
+		 " "
+		 (org-trim (concat term ": " contents)))))))
 
 (defun org-confluence-fixed-width (fixed-width contents info)
   (format "\{\{%s\}\}" contents))


### PR DESCRIPTION
I added support for verbatim, ordered, and descriptive items in the export code for Confluence.