### PR TITLE
Update ob-core.el: Add safety check for goto-char

### DIFF
--- a/lisp/ob-core.el
+++ b/lisp/ob-core.el
@@ -2279,9 +2279,12 @@ INFO may provide the values of these header arguments (in the
 	  (unwind-protect
 	      (progn
 		(when outside-scope (widen))
-		(if existing-result (goto-char existing-result)
-		  (goto-char (org-element-property :end inline))
-		  (skip-chars-backward " \t"))
+		(if existing-result 
+		    (goto-char existing-result)
+		  (let ((end-pos (org-element-property :end inline)))
+                    (when end-pos
+                      (goto-char end-pos)
+                      (skip-chars-backward " \t"))))
 		(unless inline
 		  (setq indent (current-indentation))
 		  (forward-line 1))


### PR DESCRIPTION
I've tried my own implementation of an `org-babel-execute:language` and got end error for the `goto-char` above. I'm not sure, what I would need to return from my own `org-babel-execute:language` in order to avoid that - the check above avoids that - and is hopefully a good enough fix to avoid such errors. If setting the position with `goto-char` is necessary, and `if` with an `else` branch would be a better fit - but I have no idea what to put into that branch.